### PR TITLE
Prefix unique_id with TX07KTXC in sensor config

### DIFF
--- a/TemperatureSensorArduinoReader/HomeAssistantSensor.cs
+++ b/TemperatureSensorArduinoReader/HomeAssistantSensor.cs
@@ -16,7 +16,7 @@ public class HomeAssistantSensor
             unit_of_measurement = "°C",
             device_class = "temperature",
             expire_after = 600,
-            unique_id = sensorName + "_temperature",
+            unique_id = "TX07KTXC_" + sensorName + "_temperature",
             value_template = "{% set num1 = value[4] | int(base=16,default=0) * 256 %}{% set num2 = value[5] | int(base=16,default=0) * 16 %}{% set num3 = value[6] | int(base=16,default=0) %}{{ ((num1 + num2 + num3)*0.1-122)*(5/9) }}",
             device = new
             {
@@ -35,7 +35,7 @@ public class HomeAssistantSensor
             unit_of_measurement = "%",
             device_class = "humidity",
             expire_after = 600,
-            unique_id = sensorName + "_humidity",
+            unique_id = "TX07KTXC_" + sensorName + "_humidity",
             value_template = "{% set num1 = value[7] | int(base=16,default=0) %}{% set num2 = value[8] | int(base=16,default=0) %}{{ num1 * 10 + num2 }}",
             device = new
             {
@@ -52,7 +52,7 @@ public class HomeAssistantSensor
             name = "Battery",
             state_topic = "TX07KTXC/" + sensorName + "/state",
             expire_after = 600,
-            unique_id = sensorName + "_battery",
+            unique_id = "TX07KTXC_" + sensorName + "_battery",
             value_template = "{% if value[3] | int(base=16,default=0) | bitwise_and(4) | bool %} Vybitá{% else %}OK{% endif %}",
             device = new
             {
@@ -68,7 +68,7 @@ public class HomeAssistantSensor
             name = "Trend",
             state_topic = "TX07KTXC/" + sensorName + "/state",
             expire_after = 600,
-            unique_id = sensorName + "_trend",
+            unique_id = "TX07KTXC_" + sensorName + "_trend",
             value_template = "{% set up = value[3] | int(base=16,default=0) | bitwise_and(1) | bool %}{% set down = value[3] | int(base=16,default=0) | bitwise_and(2) | bool %}{% if up %}↗{% elif down %}↘{% else %}→{% endif %}",
             device = new
             {


### PR DESCRIPTION
Updated the unique_id fields for temperature, humidity, battery, and trend sensors to be prefixed with 'TX07KTXC_' for improved identification and consistency in Home Assistant.