### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Zefek/ArduinoSerialReader/security/code-scanning/2](https://github.com/Zefek/ArduinoSerialReader/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/build.yml` at the workflow root so it applies to all jobs (including `build`).  
For this workflow, the minimal required scope is:

- `contents: read` (needed for checkout)

No write scopes are needed based on the shown steps (`restore`, `publish`, and `upload-artifact` do not require repository write access).  
Place the block right after the `on:` section (or before `jobs:`), preserving existing behavior while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
